### PR TITLE
Fixed to work with InfluxDB 0.8

### DIFF
--- a/api.go
+++ b/api.go
@@ -55,12 +55,12 @@ func PostStruct(url string, reqStruct interface{}) (string, error) {
 	marshalled, err := json.Marshal(reqStruct)
 	marshalled = bytes.ToLower(marshalled)
 	if err != nil {
-		panic(err)
+		return "", err
 	}
 	buf := bytes.NewBuffer(marshalled)
 	result, err := http.Post(url, "application/json", buf)
 	if err != nil {
-		panic(err)
+		return "", err
 	}
 	defer result.Body.Close()
 	result_buf := new(bytes.Buffer)
@@ -69,5 +69,4 @@ func PostStruct(url string, reqStruct interface{}) (string, error) {
 		return "", errors.New(result_buf.String())
 	}
 	return result_buf.String(), nil
-
 }

--- a/series.go
+++ b/series.go
@@ -1,19 +1,19 @@
 package influxdbc
 
 type Series struct {
-	Name       string
-	Columns    []string
-	DataPoints [][]string
+	Name    string
+	Columns []string
+	Points  [][]string
 }
 
 func NewSeries(name string, cols ...string) *Series {
 	s := new(Series)
 	s.Name = name
 	s.Columns = cols
-	s.DataPoints = make([][]string, 0)
+	s.Points = make([][]string, 0)
 	return s
 }
 
 func (s *Series) AddPoint(point ...string) {
-	s.DataPoints = append(s.DataPoints, point)
+	s.Points = append(s.Points, point)
 }


### PR DESCRIPTION
- panic() removed to tolerate a failure of the InfluxDB outage
- Series fields adapted to those expected by 0.8 (DataPoints -> Points)